### PR TITLE
make transport swappable

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "zipkin-simple.js",
   "scripts": {
-    "test": "lab test/*.test.js -r console -L -t 78 -c -v",
+    "test": "lab test/*.test.js test/**/*.test.js -r console -L -t 78 -c -v",
     "lint": "lab *.js -dL",
     "coverage": "lab -v -P test -L -t 80 -r html > docs/coverage.html"
   },
@@ -36,6 +36,7 @@
     "pre-commit": "^1.1.3"
   },
   "files": [
+    "transports/*.js",
     "zipkin-simple.js",
     "README.md",
     "LICENSE"

--- a/test/fake-server.js
+++ b/test/fake-server.js
@@ -1,3 +1,4 @@
+"use strict"
 
 const Http = require("http")
 const EventEmitter = require("events")

--- a/test/transports/http-batch.test.js
+++ b/test/transports/http-batch.test.js
@@ -1,0 +1,96 @@
+"use strict"
+
+const Lab = require("lab")
+const Code = require("code")
+const Transport = require("../../transports/http-batch")
+const FakeServer = require("../fake-server")
+
+const lab = exports.lab = Lab.script()
+const describe = lab.describe
+const it = lab.it
+const expect = Code.expect
+
+const FAKE_SERVER_PORT = 9090
+
+const options = {
+	port: FAKE_SERVER_PORT,
+	host: "127.0.0.1",
+	path: "/api/v1/spans",
+	batchSize: 2,
+	batcheTimeout: 100
+}
+
+describe("Transports", function () {
+
+	describe("http-batch", function () {
+
+		let fakeServer
+
+		lab.before(function (done) {
+			fakeServer = FakeServer(FAKE_SERVER_PORT, done)
+		})
+
+		lab.beforeEach(function (done) {
+			fakeServer.reset()
+			done()
+		})
+
+		lab.after(function (done) {
+			fakeServer.stop()
+			done()
+		})
+
+		it("sends received data to the correct url in batches", function (done) {
+
+			fakeServer.on("request", function (data) {
+				var expectedBatchSize = 2
+
+				expect(data.url).to.equal("/api/v1/spans")
+				expect(data.body).to.be.an.array()
+				expect(data.body).to.have.length(expectedBatchSize)
+				expect(data.body[0]).to.equal({
+					traceId: "test trace",
+					id: "test span"
+				})
+				expect(data.body[1]).to.equal({
+					traceId: "test trace 2",
+					id: "test span 2"
+				})
+
+				done()
+			})
+
+			Transport({
+				traceId: "test trace",
+				id: "test span"
+			}, options)
+			Transport({
+				traceId: "test trace 2",
+				id: "test span 2"
+			}, options)
+
+		})
+
+		it("sends queued data on inactivity", function (done) {
+			fakeServer.on("request", function (data) {
+
+				expect(data.url).to.equal("/api/v1/spans")
+				expect(data.body).to.be.an.array()
+				expect(data.body).to.have.length(1)
+				expect(data.body[0]).to.equal({
+					traceId: "test trace 3",
+					id: "test span 3"
+				})
+
+				done()
+			})
+
+			Transport({
+				traceId: "test trace 3",
+				id: "test span 3"
+			}, options)
+		})
+
+	})
+
+})

--- a/test/transports/http-simple.test.js
+++ b/test/transports/http-simple.test.js
@@ -1,0 +1,63 @@
+const Lab = require("lab")
+const Code = require("code")
+const Transport = require("../../transports/http-simple")
+const FakeServer = require("../fake-server")
+
+const lab = exports.lab = Lab.script()
+const describe = lab.describe
+const it = lab.it
+const expect = Code.expect
+
+const FAKE_SERVER_PORT = 9090
+
+const options = {
+	port: FAKE_SERVER_PORT,
+	host: "127.0.0.1",
+	path: "/api/v1/spans"
+}
+
+describe("Transports", function () {
+
+	describe("http-simple", function () {
+
+		let fakeServer
+
+		lab.before(function (done) {
+			fakeServer = FakeServer(FAKE_SERVER_PORT, done)
+		})
+
+		lab.beforeEach(function (done) {
+			fakeServer.reset()
+			done()
+		})
+
+		lab.after(function (done) {
+			fakeServer.stop()
+			done()
+		})
+
+		it("sends received data to the correct url", function (done) {
+
+			fakeServer.on("request", function (data) {
+
+				expect(data.url).to.equal("/api/v1/spans")
+				expect(data.body).to.be.an.array()
+				expect(data.body).to.have.length(1)
+				expect(data.body[0]).to.equal({
+					traceId: "test trace",
+					id: "test span"
+				})
+
+				done()
+			})
+
+			Transport({
+				traceId: "test trace",
+				id: "test span"
+			}, options)
+
+		})
+
+	})
+
+})

--- a/test/transports/http-simple.test.js
+++ b/test/transports/http-simple.test.js
@@ -1,3 +1,5 @@
+"use strict"
+
 const Lab = require("lab")
 const Code = require("code")
 const Transport = require("../../transports/http-simple")

--- a/test/zipkin-simple.test.js
+++ b/test/zipkin-simple.test.js
@@ -24,6 +24,30 @@ function now () {
 
 describe("Zipkin client", function () {
 
+	describe("options", function () {
+
+		it("is possible to swap transport", function (done) {
+
+			function dummyTransport (data) {
+				expect(data).to.include(["traceId", "name", "id", "annotations"])
+				Client.options({transport: "http"})
+				done()
+			}
+
+			Client.options({
+				transport: dummyTransport
+			})
+
+			Client.sendClientSend(null, {
+				service: "test service",
+				name: "test name"
+			})
+
+		})
+
+
+	})
+
 	describe("Trace data manipulation", function () {
 
 		describe("getChild", function () {

--- a/test/zipkin-simple.test.js
+++ b/test/zipkin-simple.test.js
@@ -46,6 +46,19 @@ describe("Zipkin client", function () {
 
 		})
 
+		it("it cant sets to http batch transport", function (done) {
+			Client.options({transport: "http"})
+			expect(Client.send.name).to.equal("httpBatchTransport")
+
+			done()
+		})
+
+		it("it cant sets to http simple transport", function (done) {
+			Client.options({transport: "http-simple"})
+			expect(Client.send.name).to.equal("httpSimpleTransport")
+
+			done()
+		})
 
 	})
 

--- a/test/zipkin-simple.test.js
+++ b/test/zipkin-simple.test.js
@@ -3,26 +3,28 @@
 const Lab = require("lab")
 const Code = require("code")
 const Zipkin = require("..")
-const FakeHttp = require("./fake-server")
 
 const lab = exports.lab = Lab.script()
 const describe = lab.describe
 const it = lab.it
 const expect = Code.expect
 
-const FAKE_SERVER_PORT = 9090
 const TO_MICROSECONDS = 1000
 
-const Client = new Zipkin({
-	port: 9090,
-	sampling: 1
-})
+const Client = new Zipkin({sampling: 1})
 
 function now () {
 	return new Date().getTime() * TO_MICROSECONDS
 }
 
+function noop () {}
+
 describe("Zipkin client", function () {
+
+	lab.beforeEach(function resetTransport (done) {
+		Client.options({transport: noop})
+		done()
+	})
 
 	describe("options", function () {
 
@@ -30,7 +32,6 @@ describe("Zipkin client", function () {
 
 			function dummyTransport (data) {
 				expect(data).to.include(["traceId", "name", "id", "annotations"])
-				Client.options({transport: "http"})
 				done()
 			}
 
@@ -118,21 +119,6 @@ describe("Zipkin client", function () {
 	})
 
 	describe("Standard annotations", function () {
-		let fakeHttp
-
-		lab.before(function (done) {
-			fakeHttp = FakeHttp(FAKE_SERVER_PORT, done)
-		})
-
-		lab.beforeEach(function (done) {
-			fakeHttp.reset()
-			done()
-		})
-
-		lab.after(function (done) {
-			fakeHttp.stop()
-			done()
-		})
 
 		describe("sendClientSend", function () {
 			const traceData = {
@@ -145,11 +131,9 @@ describe("Zipkin client", function () {
 
 			it("sends data to zipkin", function (done) {
 
-				fakeHttp.on("request", function (data) {
+				function testTransport (data) {
 					try {
-						expect(data.url).to.equal("/api/v1/spans")
-						expect(data.body).to.be.array()
-						expect(data.body).to.include({
+						expect(data).to.include({
 							traceId: "test traceId",
 							name: "test name",
 							id: "test spanId",
@@ -164,16 +148,17 @@ describe("Zipkin client", function () {
 							}],
 							binaryAnnotations: []
 						})
-						expect(data.body[0].annotations[0]).to.include("timestamp")
-						expect(data.body[0]).to.not.include("duration")
+						expect(data.annotations[0]).to.include("timestamp")
+						expect(data).to.not.include("duration")
 					}
 					catch (ex) {
 						return done(ex)
 					}
 
 					done()
-				})
+				}
 
+				Client.options({transport: testTransport})
 				Client.sendClientSend(traceData, {
 					service: "test service",
 					name: "test name"
@@ -195,10 +180,11 @@ describe("Zipkin client", function () {
 			})
 
 			it("should not send data for not sampled traces", function (done) {
-				fakeHttp.on("request", function (data) {
+				function testTransport () {
 					done("Shouldn't receive data")
-				})
+				}
 
+				Client.options({transport: testTransport})
 				Client.sendClientSend({sampled: false}, {
 					service: "test service",
 					name: "test name"
@@ -225,11 +211,9 @@ describe("Zipkin client", function () {
 
 			it("sends data to zipkin", function (done) {
 
-				fakeHttp.on("request", function (data) {
+				function testTransport (data) {
 					try {
-						expect(data.url).to.equal("/api/v1/spans")
-						expect(data.body).to.be.array()
-						expect(data.body).to.include({
+						expect(data).to.include({
 							traceId: "test traceId",
 							name: "test name",
 							id: "test spanId",
@@ -243,17 +227,18 @@ describe("Zipkin client", function () {
 							}],
 							binaryAnnotations: []
 						})
-						expect(data.body[0]).to.not.include("timestamp")
-						expect(data.body[0].annotations[0]).to.include("timestamp")
-						expect(data.body[0].duration).to.equal(data.body[0].annotations[0].timestamp - traceData.timestamp)
+						expect(data).to.not.include("timestamp")
+						expect(data.annotations[0]).to.include("timestamp")
+						expect(data.duration).to.equal(data.annotations[0].timestamp - traceData.timestamp)
 					}
 					catch (ex) {
 						return done(ex)
 					}
 
 					done()
-				})
+				}
 
+				Client.options({transport: testTransport})
 				Client.sendClientRecv(traceData, {
 					service: "test service",
 					name: "test name"
@@ -279,11 +264,9 @@ describe("Zipkin client", function () {
 
 			it("sends data to zipkin", function (done) {
 
-				fakeHttp.on("request", function (data) {
+				function testTransport (data) {
 					try {
-						expect(data.url).to.equal("/api/v1/spans")
-						expect(data.body).to.be.array()
-						expect(data.body).to.include({
+						expect(data).to.include({
 							traceId: "test traceId",
 							name: "test name",
 							id: "test spanId",
@@ -297,17 +280,18 @@ describe("Zipkin client", function () {
 							}],
 							binaryAnnotations: []
 						})
-						expect(data.body[0]).to.not.include("timestamp")
-						expect(data.body[0].annotations[0]).to.include("timestamp")
-						expect(data.body[0]).to.not.include("duration")
+						expect(data).to.not.include("timestamp")
+						expect(data.annotations[0]).to.include("timestamp")
+						expect(data).to.not.include("duration")
 					}
 					catch (ex) {
 						return done(ex)
 					}
 
 					done()
-				})
+				}
 
+				Client.options({transport: testTransport})
 				Client.sendServerSend(traceData, {
 					service: "test service",
 					name: "test name"
@@ -325,11 +309,9 @@ describe("Zipkin client", function () {
 					serverOnly: true
 				}
 
-				fakeHttp.on("request", function (data) {
+				function testTransport (data) {
 					try {
-						expect(data.url).to.equal("/api/v1/spans")
-						expect(data.body).to.be.array()
-						expect(data.body).to.include({
+						expect(data).to.include({
 							traceId: "test traceId",
 							name: "test name",
 							id: "test spanId",
@@ -343,17 +325,18 @@ describe("Zipkin client", function () {
 							}],
 							binaryAnnotations: []
 						})
-						expect(data.body[0]).to.not.include("timestamp")
-						expect(data.body[0].annotations[0]).to.include("timestamp")
-						expect(data.body[0].duration).to.equal(data.body[0].annotations[0].timestamp - traceData.timestamp)
+						expect(data).to.not.include("timestamp")
+						expect(data.annotations[0]).to.include("timestamp")
+						expect(data.duration).to.equal(data.annotations[0].timestamp - traceData.timestamp)
 					}
 					catch (ex) {
 						return done(ex)
 					}
 
 					done()
-				})
+				}
 
+				Client.options({transport: testTransport})
 				Client.sendServerSend(traceData, {
 					service: "test service",
 					name: "test name"
@@ -379,11 +362,9 @@ describe("Zipkin client", function () {
 
 			it("sends data to zipkin", function (done) {
 
-				fakeHttp.on("request", function (data) {
+				function testTransport (data) {
 					try {
-						expect(data.url).to.equal("/api/v1/spans")
-						expect(data.body).to.be.array()
-						expect(data.body).to.include({
+						expect(data).to.include({
 							traceId: "test traceId",
 							name: "test name",
 							id: "test spanId",
@@ -397,17 +378,18 @@ describe("Zipkin client", function () {
 							}],
 							binaryAnnotations: []
 						})
-						expect(data.body[0]).to.not.include("timestamp")
-						expect(data.body[0].annotations[0]).to.include("timestamp")
-						expect(data.body[0]).to.not.include("duration")
+						expect(data).to.not.include("timestamp")
+						expect(data.annotations[0]).to.include("timestamp")
+						expect(data).to.not.include("duration")
 					}
 					catch (ex) {
 						return done(ex)
 					}
 
 					done()
-				})
+				}
 
+				Client.options({transport: testTransport})
 				Client.sendServerRecv(traceData, {
 					service: "test service",
 					name: "test name"
@@ -417,11 +399,9 @@ describe("Zipkin client", function () {
 
 			it("sends timestamp and creates a serverOnly trace if no trace passed in", function (done) {
 
-				fakeHttp.on("request", function (data) {
+				function testTransport (data) {
 					try {
-						expect(data.url).to.equal("/api/v1/spans")
-						expect(data.body).to.be.array()
-						expect(data.body).to.include({
+						expect(data).to.include({
 							name: "test name",
 							annotations: [{
 								value: "sr",
@@ -433,17 +413,18 @@ describe("Zipkin client", function () {
 							}],
 							binaryAnnotations: []
 						})
-						expect(data.body[0]).to.include("timestamp")
-						expect(data.body[0].annotations[0]).to.include("timestamp")
-						expect(data.body[0]).to.not.include("duration")
+						expect(data).to.include("timestamp")
+						expect(data.annotations[0]).to.include("timestamp")
+						expect(data).to.not.include("duration")
 					}
 					catch (ex) {
 						return done(ex)
 					}
 
 					done()
-				})
+				}
 
+				Client.options({transport: testTransport})
 				const data = Client.sendServerRecv(null, {
 					service: "test service",
 					name: "test name"

--- a/transports/http-batch.js
+++ b/transports/http-batch.js
@@ -1,0 +1,56 @@
+"use strict"
+
+var Wreck = require("wreck")
+
+var HTTP_OK = 200
+var HTTP_RECEIVED = 202
+
+var DEFAULT_BATCH_SIZE = 5
+var DEFAULT_BATCH_TIMEOUT = 1000
+
+var queue = []
+var timer = null
+
+function send (body, options) {
+	clearTimeout(timer)
+	timer = null
+
+	if (body.length === 0) {
+		return
+	}
+
+	const path = "http://" + options.host + ":" + options.port + options.path
+	Wreck.post(path, {payload: body}, function sent (err, response, body) {
+		if (!options.debug) {
+			return
+		}
+
+		if (err) {
+			return console.log("An error occurred sending trace data", err)
+		}
+
+		if (response.statusCode !== HTTP_OK && response.statusCode !== HTTP_RECEIVED) {
+			return console.log("Server returned an error:", response.statusCode, "\n", body)
+		}
+	})
+}
+
+function flush (options) {
+	send(queue.splice(0, queue.length), options)
+}
+
+function httpBatchTransport (data, options) {
+	queue.push(data)
+
+	if (queue.length >= (options.batchSize || DEFAULT_BATCH_SIZE)) {
+		send(queue.splice(0, queue.length), options)
+	}
+	else if (!timer) {
+		timer = setTimeout(function () {
+			flush(options)
+		}, options.batchTimeout || DEFAULT_BATCH_TIMEOUT)
+	}
+}
+
+
+module.exports = httpBatchTransport

--- a/transports/http-simple.js
+++ b/transports/http-simple.js
@@ -1,3 +1,4 @@
+"use strict"
 
 var Wreck = require("wreck")
 

--- a/transports/http-simple.js
+++ b/transports/http-simple.js
@@ -1,0 +1,24 @@
+
+var Wreck = require("wreck")
+
+var HTTP_OK = 200
+var HTTP_RECEIVED = 202
+
+function httpSimpleTransport (body, options) {
+	const path = "http://" + options.host + ":" + options.port + options.path
+	Wreck.post(path, {payload: [body]}, function sent (err, response, body) {
+		if (!options.debug) {
+			return
+		}
+
+		if (err) {
+			return console.log("An error occurred sending trace data", err)
+		}
+
+		if (response.statusCode !== HTTP_OK && response.statusCode !== HTTP_RECEIVED) {
+			return console.log("Server returned an error:", response.statusCode, "\n", body)
+		}
+	})
+}
+
+module.exports = httpSimpleTransport

--- a/zipkin-simple.js
+++ b/zipkin-simple.js
@@ -1,8 +1,6 @@
 
-var Wreck = require("wreck")
+var HttpSimpleTransport = require("./transports/http-simple")
 
-var HTTP_OK = 200
-var HTTP_RECEIVED = 202
 var TO_MICROSECONDS = 1000
 var ID_LENGTH = 16
 var ID_DIGITS = "0123456789abcdef"
@@ -15,22 +13,6 @@ var DEFAULT_OPTIONS = {
 	path: "/api/v1/spans"
 }
 
-function send (body, options) {
-	const path = "http://" + options.host + ":" + options.port + options.path
-	Wreck.post(path, {payload: [body]}, function sent (err, response, body) {
-		if (!options.debug) {
-			return
-		}
-
-		if (err) {
-			return console.log("An error occurred sending trace data", err)
-		}
-
-		if (response.statusCode !== HTTP_OK && response.statusCode !== HTTP_RECEIVED) {
-			return console.log("Server returned an error:", response.statusCode, "\n", body)
-		}
-	})
-}
 
 function generateTimestamp () {
 	// use process.hrtime?
@@ -58,10 +40,10 @@ function zipkinSimple (options) {
 }
 
 zipkinSimple.prototype.buildOptions = function buildOptions () {
-	this.send = send
+	this.send = HttpSimpleTransport
 
 	if (this.opts.transport === "http-simple") {
-		this.send = send
+		this.send = HttpSimpleTransport
 	}
 
 	if (typeof this.opts.transport === "function") {

--- a/zipkin-simple.js
+++ b/zipkin-simple.js
@@ -1,6 +1,7 @@
 "use strict"
 
 var HttpSimpleTransport = require("./transports/http-simple")
+var HttpBatchTransport = require("./transports/http-batch")
 
 var TO_MICROSECONDS = 1000
 var ID_LENGTH = 16
@@ -41,7 +42,7 @@ function zipkinSimple (options) {
 }
 
 zipkinSimple.prototype.buildOptions = function buildOptions () {
-	this.send = HttpSimpleTransport
+	this.send = HttpBatchTransport
 
 	if (this.opts.transport === "http-simple") {
 		this.send = HttpSimpleTransport

--- a/zipkin-simple.js
+++ b/zipkin-simple.js
@@ -1,3 +1,4 @@
+"use strict"
 
 var HttpSimpleTransport = require("./transports/http-simple")
 

--- a/zipkin-simple.js
+++ b/zipkin-simple.js
@@ -53,13 +53,26 @@ function generateId () {
 
 function zipkinSimple (options) {
 	this.counter = 0
-	this.options = Object.assign({}, DEFAULT_OPTIONS, options)
+	this.opts = Object.assign({}, DEFAULT_OPTIONS, options)
+	this.buildOptions()
+}
+
+zipkinSimple.prototype.buildOptions = function buildOptions () {
+	this.send = send
+
+	if (this.opts.transport === "http-simple") {
+		this.send = send
+	}
+
+	if (typeof this.opts.transport === "function") {
+		this.send = this.opts.transport
+	}
 }
 
 zipkinSimple.prototype.shouldSample = function shouldSample () {
 	this.counter++
 
-	if (this.counter * this.options.sampling >= 1) {
+	if (this.counter * this.opts.sampling >= 1) {
 		this.counter = 0
 		return true
 	}
@@ -131,7 +144,7 @@ zipkinSimple.prototype.sendTrace = function sendTrace (trace, data) {
 		}
 	}
 
-	send(body, this.options)
+	this.send(body, this.opts)
 }
 
 zipkinSimple.prototype.traceWithAnnotation = function traceWithAnnotation (trace, data, annotation) {
@@ -173,10 +186,11 @@ zipkinSimple.prototype.sendServerRecv = function sendServerRecv (trace, data) {
 
 zipkinSimple.prototype.options = function setOptions (opts) {
 	if (opts) {
-		Object.assign(this.options, opts)
+		Object.assign(this.opts, opts)
+		this.buildOptions()
 	}
 
-	return this.options
+	return this.opts
 }
 
 zipkinSimple.prototype.get_child = zipkinSimple.prototype.getChild


### PR DESCRIPTION
Also add (and make default) a batched http transport. 
Http-simple transport will instead post traces as soon we'll receive them
